### PR TITLE
Added support for sh1107 with OLED display 64x128, e.g. Waveshare Pico OLED 1.3

### DIFF
--- a/src/displays/sh1107.rs
+++ b/src/displays/sh1107.rs
@@ -5,6 +5,29 @@ use display_interface::{AsyncWriteOnlyDataCommand, DisplayError};
 
 use crate::command::{Command, VcomhLevel};
 
+/// Generic 64x128 with SH1107 controller
+#[derive(Debug, Clone, Copy)]
+pub struct Sh1107_64_128 {}
+
+impl DisplayVariant for Sh1107_64_128 {
+    const WIDTH: u8 = 64;
+    const HEIGHT: u8 = 128;
+    const COLUMN_OFFSET: u8 = 32;
+
+    async fn init_column_mode<DI>(
+        iface: &mut DI,
+        //display_rotation: DisplayRotation,
+    ) -> Result<(), DisplayError>
+    where
+        DI: AsyncWriteOnlyDataCommand,
+    {
+        init_column_mode_common(iface, Self::dimensions()).await?;
+        Command::ComPinConfig(true).send(iface).await?;
+
+        Ok(())
+    }
+}
+
 /// Generic 128x128 with SH1107 controller
 #[derive(Debug, Clone, Copy)]
 pub struct Sh1107_128_128 {}


### PR DESCRIPTION
Hi there

Sorry to bother you, but I got the Waveshare Pico OLED 1.3 working with these additions to your crate. As far as I can tell everything is working so I'm trying to do the right thing and contribute.

Cheerio
Beat