### PR TITLE
add sh1106 128x64 module

### DIFF
--- a/src/displays/mod.rs
+++ b/src/displays/mod.rs
@@ -3,6 +3,7 @@
 //! This driver can be used in different modes. A mode defines how the driver will behave, and what
 //! methods it exposes. Look at the modes below for more information on what they expose.
 
+pub mod sh1106;
 pub mod sh1107;
 pub mod sh1108;
 pub mod ssd1309;

--- a/src/displays/sh1106.rs
+++ b/src/displays/sh1106.rs
@@ -1,0 +1,28 @@
+//! SH1106 display variant
+
+use crate::{display::DisplayVariant, command::Command};
+use display_interface::{AsyncWriteOnlyDataCommand, DisplayError};
+
+/// Generic 128x64 with SH1106 controller
+#[derive(Debug, Clone, Copy)]
+pub struct Sh1106_128_64 {}
+
+impl DisplayVariant for Sh1106_128_64 {
+    const WIDTH: u8 = 128;
+    const HEIGHT: u8 = 64;
+    const COLUMN_OFFSET: u8 = 2;
+
+    async fn init_column_mode<DI>(
+        iface: &mut DI,
+        //display_rotation: DisplayRotation,
+    ) -> Result<(), DisplayError>
+    where
+        DI: AsyncWriteOnlyDataCommand,
+    {
+        super::sh1107::init_column_mode_common(iface, Self::dimensions()).await?;
+        Command::DisplayOffset(0).send(iface).await?;
+        Command::ComPinConfig(true).send(iface).await?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Tested stm32g0 with the generic 1.3" i2c oled module pictured here
<img width="235" height="263" alt="image" src="https://github.com/user-attachments/assets/d7de848d-2cf7-4b7a-8f04-580ff7e43242" />